### PR TITLE
add slug field to series

### DIFF
--- a/lib/tvdb2/series.rb
+++ b/lib/tvdb2/series.rb
@@ -6,7 +6,7 @@ module Tvdb2
     # Fields returned from api endpoint `GET /search/series` (search)
     INDEX_FIELDS = [
       :aliases, :banner, :firstAired, :id, :network, :overview, :seriesName,
-      :status, :slug
+      :slug, :status
     ]
 
     # Other fields with {INDEX_FIELDS} returned from api endpoint `GET
@@ -23,7 +23,7 @@ module Tvdb2
     attr_reader :added, :airsDayOfWeek, :airsTime, :aliases, :banner,
       :firstAired, :genre, :id, :imdbId, :lastUpdated, :network, :networkId,
       :overview, :rating, :runtime, :seriesId, :seriesName, :siteRating,
-      :siteRatingCount, :status, :slug, :zap2itId
+      :siteRatingCount, :slug, :status, :zap2itId
     # FIELDS.each do |field|
     #   attr_reader field
     # end

--- a/lib/tvdb2/series.rb
+++ b/lib/tvdb2/series.rb
@@ -6,7 +6,7 @@ module Tvdb2
     # Fields returned from api endpoint `GET /search/series` (search)
     INDEX_FIELDS = [
       :aliases, :banner, :firstAired, :id, :network, :overview, :seriesName,
-      :status
+      :status, :slug
     ]
 
     # Other fields with {INDEX_FIELDS} returned from api endpoint `GET
@@ -23,7 +23,7 @@ module Tvdb2
     attr_reader :added, :airsDayOfWeek, :airsTime, :aliases, :banner,
       :firstAired, :genre, :id, :imdbId, :lastUpdated, :network, :networkId,
       :overview, :rating, :runtime, :seriesId, :seriesName, :siteRating,
-      :siteRatingCount, :status, :zap2itId
+      :siteRatingCount, :status, :slug, :zap2itId
     # FIELDS.each do |field|
     #   attr_reader field
     # end


### PR DESCRIPTION
Hi,

thanks for this nice gem.
I'm using it in a side-project and it is working great so far :tada:

Could we please add the `slug` attribute to `series`?
It is returned in both index and show series endpoints of the API.

* https://api.thetvdb.com/swagger#!/Search/get_search_series
* https://api.thetvdb.com/swagger#!/Series/get_series_id

I've already gave it a try by pointing my `Gemfile` entry to this branch.

Thank you,

Klaus