### PR TITLE
remove URI.escape calls in client

### DIFF
--- a/lib/tvdb2/client.rb
+++ b/lib/tvdb2/client.rb
@@ -98,14 +98,14 @@ module Tvdb2
     # language param is required to invalidate memoist cache on different language
     def get(path, params = {}, language = @language)
       puts ">>> GET API REQUEST to '#{path}' with language '#{language}'" if ENV['DEBUG']
-      self.class.get(URI.escape(path), headers: build_headers, query: params)
+      self.class.get(path, headers: build_headers, query: params)
     end
     memoize :get
 
     # :nodoc:
     def post(path, params = {}, language = @language)
       puts ">>> POST API REQUEST to '#{path}' with language '#{language}'" if ENV['DEBUG']
-      self.class.post(URI.escape(path), headers: build_headers, body: params.to_json)
+      self.class.post(path, headers: build_headers, body: params.to_json)
     end
     memoize :post
 


### PR DESCRIPTION
Hi,

I recently updated my application using this library to Ruby 2.7 and just noticed that it started printing the following message in the logs:

> lib/tvdb2/client.rb:108: warning: URI.escape is obsolete

I tried changing it to `CGI.escape` or `URI.encode_www_form_component` as [suggested](https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI/Escape.html#method-i-escape-label-Description) in the docs but this would also encode the leading slash of the path component. After checking the API docs of TheTVDB I'm almost sure there shouldn't be a need to escape the paths anyways as they only contain URL safe chars.