### PR TITLE
handle data being nil on page=2 call

### DIFF
--- a/lib/tvdb2/client.rb
+++ b/lib/tvdb2/client.rb
@@ -131,7 +131,7 @@ module Tvdb2
     # :nodoc:
     def build_array_result(path, params = {}, klass = TvdbStruct)
       build_result(path, params, []) do |data|
-        data.map{|x| klass.new(self, x)}
+        Array(data).map{|x| klass.new(self, x)}
       end
     end
 


### PR DESCRIPTION
Currently the pagination logic seems to not use the total number of pages available in the API but simply calling the endpoints for (e.g. episodes) until it gets a count of record less than the "per page" one (100).

This seems to have been working fine until a recent change in the API.

Now the 2nd page with no entries seems to return `null` instead of `[]` in `data` attribute.

Steps to reproduce:

```ruby
TVDB.new(apikey: 'changeme').series(81189).episodes
# => NoMethodError undefined method `map' for nil:NilClass
```

This quick fix should address the issue without reworking the pagination logic.